### PR TITLE
Updates to watch_new_commits for closures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [0.3.0](https://github.com/tjtelan/git-event-rs/compare/v0.2.1...v0.3.0) (2021-02-27)
+- Updating `watch_new_commits` to be `async`
+- Updating `watch_new_commits` input closure, to return `GitRepoState` to user
+- Updating `watch_new_commits` params with `pre_run` to call the closure once before polling for updates
+- Offering a sync version of `watch_new_commits` called `watch_new_commits_sync`
+- Changed `update_state` input to `&mut self`
+- `update_state` sets changed paths between commits.
 # [0.2.1](https://github.com/tjtelan/git-event-rs/compare/v0.2.0...v0.2.1) (2021-02-12)
 - Updating `git-meta` to `^0.2`
 # [0.2.0](https://github.com/tjtelan/git-event-rs/compare/v0.1.0...v0.2.0) (2021-02-08)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,9 +11,9 @@ dependencies = [
 
 [[package]]
 name = "adler"
-version = "0.2.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
@@ -75,9 +75,9 @@ checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cc"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 dependencies = [
  "jobserver",
 ]
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
+checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
 dependencies = [
  "atty",
  "humantime",
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
@@ -180,7 +180,7 @@ checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "git-event"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "color-eyre",
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "git-meta"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010cceefffaa30dd500f231b498835dca8f01e6b0b3e6fb4f1dd4416fd547b3b"
+checksum = "bb2f1a774adf6c4e372afe52b903f928e290d34f4e96804df3b3f50fd49b03e2"
 dependencies = [
  "chrono",
  "color-eyre",
@@ -269,9 +269,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "idna"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
+checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "indenter"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4d5eb2e114fec2b7fe0fadc22888ad2658789bb7acac4dbee9cf8389f971ec8"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "instant"
@@ -310,9 +310,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.85"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ccac4b00700875e6a07c6cde370d44d32fa01c5a65cdd2fca6858c479d28bb3"
+checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
 
 [[package]]
 name = "libgit2-sys"
@@ -386,9 +386,9 @@ checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
  "autocfg",
@@ -396,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.7"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
+checksum = "a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a"
 dependencies = [
  "libc",
  "log",
@@ -472,9 +472,9 @@ checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 
 [[package]]
 name = "once_cell"
-version = "1.5.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+checksum = "10acf907b94fc1b1a152d08ef97e7759650268cf986bf127f387e602b02c7e5a"
 
 [[package]]
 name = "openssl-probe"
@@ -514,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccb628cad4f84851442432c60ad8e1f607e29752d0bf072cbd0baf28aa34272"
+checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
 dependencies = [
  "cfg-if",
  "instant",
@@ -555,18 +555,21 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "regex"
@@ -707,9 +710,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6714d663090b6b0acb0fa85841c6d66233d150cdb2602c8f9b8abb03370beb3f"
+checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
 dependencies = [
  "autocfg",
  "bytes",
@@ -727,9 +730,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42517d2975ca3114b22a16192634e8241dc5cc1f130be194645970cc1c371494"
+checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -738,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.23"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d40a22fd029e33300d8d89a5cc8ffce18bb7c587662f54629e94c9de5487f3"
+checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -750,9 +753,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f080ea7e4107844ef4766459426fa2d5c1ada2e47edba05dc7fa99d9629f47"
+checksum = "a8a9bd1db7706f2373a190b0d067146caa39350c486f3d455b0e33b431f94c07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -780,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
+checksum = "8ab8966ac3ca27126141f7999361cc97dd6fb4b71da04c02044fa9045d98bb96"
 dependencies = [
  "sharded-slab",
  "thread_local",
@@ -800,9 +803,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
+checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
 dependencies = [
  "tinyvec",
 ]
@@ -821,9 +824,9 @@ checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "url"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
+checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "git-event"
 readme = "README.md"
 repository = "https://github.com/tjtelan/git-event-rs"
-version = "0.2.1"
+version = "0.3.0"
 
 [badges.maintenance]
 status = "actively-developed"
@@ -21,7 +21,7 @@ color-eyre = "^0.5"
 mktemp = "^0.4"
 log = "^0.4"
 chrono = "^0.4"
-git-meta = "^0.2"
+git-meta = "^0.3"
 
 [dev-dependencies]
 tokio = { version = "^1.1", features = ["full"] }

--- a/examples/oneshot-private.rs
+++ b/examples/oneshot-private.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<()> {
         passphrase: None,
     };
 
-    let watcher = GitRepoWatchHandler::new(test_url.to_string())?
+    let mut watcher = GitRepoWatchHandler::new(test_url.to_string())?
         .with_credentials(Some(clone_creds))
         .with_shallow_clone(true);
 

--- a/examples/oneshot.rs
+++ b/examples/oneshot.rs
@@ -6,7 +6,7 @@ use git_event::GitRepoWatchHandler;
 async fn main() -> Result<()> {
     let test_url = "https://github.com/rust-lang/crates.io-index.git";
 
-    let watcher = GitRepoWatchHandler::new(test_url)?.with_shallow_clone(true);
+    let mut watcher = GitRepoWatchHandler::new(test_url)?.with_shallow_clone(true);
 
     let state = watcher.update_state().await?;
 

--- a/examples/with-commit.rs
+++ b/examples/with-commit.rs
@@ -6,9 +6,21 @@ use git_event::GitRepoWatchHandler;
 async fn main() -> Result<()> {
     // You probably want to change this to a repo that you own.
     // Push a new commit. Pushing to a new branch work too.
-    let test_url = "https://github.com/rust-lang/crates.io-index.git";
+    //let test_url = "https://github.com/rust-lang/crates.io-index.git";
+    let test_url = "https://github.com/tjtelan/git-event-rs.git";
+    let branch = "main".to_string();
+    let commit_id = "1699676a8f1704006ed0126164c532978bc284a4".to_string();
 
-    let mut watcher = GitRepoWatchHandler::new(test_url)?.with_shallow_clone(true);
+    let mut watcher = GitRepoWatchHandler::new(test_url)?
+        //.with_path(tempdir.to_path_buf())
+        .with_branch(Some(branch))
+        .with_commit(Some(commit_id));
+
+    println!("Watcher: {:?}", watcher.state.clone().unwrap());
+
+    let state = watcher.update_state().await?;
+
+    println!("Watcher after update: {:?}", state);
 
     let _ = watcher
         .watch_new_commits(true, move |state| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,32 +2,37 @@
 use chrono::{DateTime, Utc};
 use color_eyre::eyre::Result;
 use mktemp::Temp;
-use std::collections::HashMap;
 use std::thread::sleep;
 use std::time::Duration;
+use std::{collections::HashMap, path::PathBuf};
 
-use log::{debug, info};
+use log::{debug, error, info};
 
 use git_meta::{GitCommitMeta, GitCredentials, GitRepo};
 
 type BranchHeads = HashMap<String, GitCommitMeta>;
+type PathAlert = HashMap<String, Vec<PathBuf>>;
 
 #[derive(Clone, Debug)]
 pub struct GitRepoWatchHandler {
     pub repo: GitRepo,
     pub state: Option<GitRepoState>,
     pub branch_filter: Option<Vec<String>>,
+    pub path_filter: Option<Vec<PathBuf>>,
     pub use_shallow: bool,
     pub poll_freq: Duration,
-    // TODO:
-    //path_filter: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct GitRepoState {
     pub last_updated: Option<DateTime<Utc>>,
     pub branch_heads: BranchHeads,
+    pub path_alert: PathAlert,
 }
+
+// Create an iterator for BranchHeads
+
+// I need to be able to start the state at an arbitrary place
 
 impl GitRepoWatchHandler {
     pub fn new<U: AsRef<str>>(url: U) -> Result<Self> {
@@ -35,9 +40,71 @@ impl GitRepoWatchHandler {
             repo: GitRepo::new(url)?,
             state: None,
             branch_filter: None,
+            path_filter: None,
             use_shallow: false,
             poll_freq: Duration::from_secs(5),
         })
+    }
+
+    ///// Set the current filesystem path
+    //pub fn with_path(mut self, path: PathBuf) -> Self {
+    //    self.repo = self.repo.with_path(path);
+    //    self
+    //}
+
+    /// Set the current repo branch
+    pub fn with_branch(mut self, branch: Option<String>) -> Self {
+        self.repo = self.repo.with_branch(branch);
+        self
+    }
+
+    /// Set the current repo commit id.
+    /// If you're using `with_commit()` to build a `GitRepoWatcher` with `new()
+    /// then use `with_commit()` as the end of the chain
+    pub fn with_commit(mut self, id: Option<String>) -> Self {
+        // We're going to do a deep clone in order to build this...
+        let tempdir = Temp::new_dir().unwrap();
+
+        let _clone = self.repo.git_clone(tempdir.to_path_buf()).unwrap();
+        let repo =
+            GitRepo::open(tempdir.to_path_buf(), self.repo.branch.clone(), id.clone()).unwrap();
+
+        //println!("opened: {:?}", repo.list_files_changed_at(id.clone().unwrap()));
+
+        let mut path_alert: HashMap<String, Vec<PathBuf>> = HashMap::new();
+        // Get the files changed in the HEAD commit
+        let changed_paths = repo
+            .list_files_changed_at(repo.clone().head.expect("No HEAD commit set").id)
+            .expect("Error retrieving changed paths");
+
+        //println!("{:?}", &changed_paths);
+
+        if let Some(paths) = changed_paths {
+            path_alert.insert(repo.clone().branch.unwrap(), paths);
+        }
+
+        self.repo = repo;
+
+        let mut repo_report = GitRepoState::default();
+
+        // Build a `BranchHeads` with just one entry: `id`
+        let mut head = HashMap::new();
+        head.insert(
+            self.repo.branch.clone().unwrap(),
+            GitCommitMeta {
+                id: self.repo.head.clone().unwrap().id,
+                message: self.repo.head.clone().unwrap().message,
+                timestamp: self.repo.head.clone().unwrap().timestamp,
+            },
+        );
+
+        repo_report.branch_heads = head;
+        repo_report.last_updated = Some(Utc::now());
+        repo_report.path_alert = path_alert;
+
+        self.state = Some(repo_report);
+        self.repo = self.repo.with_commit(id);
+        self
     }
 
     pub fn with_credentials(mut self, creds: Option<GitCredentials>) -> Self {
@@ -47,6 +114,11 @@ impl GitRepoWatchHandler {
 
     pub fn with_branch_filter(mut self, branch_list: Option<Vec<String>>) -> Self {
         self.branch_filter = branch_list;
+        self
+    }
+
+    pub fn with_path_filter(mut self, path_list: Option<Vec<PathBuf>>) -> Self {
+        self.path_filter = path_list;
         self
     }
 
@@ -60,12 +132,19 @@ impl GitRepoWatchHandler {
         self
     }
 
+    ///// Reset the repo and state with the current branch and commit id
+    //pub fn reset(mut self) {
+    //    // Re-open repo
+    //    // Re-init GitCommitMeta
+    //}
+
     pub fn state(self) -> Option<GitRepoState> {
         self.state
     }
 
-    // Perform shallow clone, update the internal state, and return current `GitRepoState`
-    pub async fn update_state(mut self) -> Result<GitRepoState> {
+    fn _update_state(&mut self) -> Result<GitRepoState> {
+        let prev_state = self.clone();
+
         let temp_path = Temp::new_dir()?;
 
         match &self.use_shallow {
@@ -97,7 +176,41 @@ impl GitRepoWatchHandler {
             .clone()
             .get_remote_branch_head_refs(self.branch_filter.clone())?;
 
-        repo_report.branch_heads = branch_heads;
+        repo_report.branch_heads = branch_heads.clone();
+
+        // Update any active path triggers from the previous branch heads
+        let mut path_alert = HashMap::new();
+
+        // If there are no existing path filters, then just list all the changed files between commits
+        for (branch, commit) in branch_heads {
+            // Try to get a previous commit
+            if let Some(c) = prev_state
+                .state
+                .clone()
+                .unwrap_or(GitRepoState::default())
+                .branch_heads
+                .get(&branch)
+            {
+                let paths = self
+                    .repo
+                    .list_files_changed_between(commit.id, c.clone().id)?;
+                if let Some(p) = paths {
+                    path_alert.insert(branch, p);
+                } else {
+                    error!("There are no ")
+                }
+                //else {
+                //    println!("DEBUG: No changes in branch {} found", &branch);
+                //}
+            } else {
+                let paths = self.repo.list_files_changed_at(commit.id)?;
+                if let Some(p) = paths {
+                    path_alert.insert(branch, p);
+                }
+            };
+        }
+
+        repo_report.path_alert = path_alert;
         repo_report.last_updated = Some(Utc::now());
 
         // Explicitly delete the clone
@@ -107,54 +220,105 @@ impl GitRepoWatchHandler {
         Ok(repo_report)
     }
 
-    // FIXME: Can this be modified so a closure can access state?
-    pub fn watch_new_commits<F>(&mut self, closure: F) -> Result<()>
+    // Perform shallow clone, update the internal state, and return current `GitRepoState`
+    pub async fn update_state(&mut self) -> Result<GitRepoState> {
+        self._update_state()
+    }
+
+    // Sync version of `update_state()`
+    pub fn update_state_sync(&mut self) -> Result<GitRepoState> {
+        self._update_state()
+    }
+
+    pub async fn watch_new_commits<F>(&mut self, pre_run: bool, closure: F) -> Result<()>
     where
-        F: FnOnce() + Copy,
+        F: Fn(GitRepoState),
     {
-        // We are going to clone the repo into this directory
-        let temp_dir = Temp::new_dir().unwrap();
+        let mut branch_heads_state = self.update_state().await?;
 
-        match &self.use_shallow {
-            true => {
-                debug!("Shallow clone");
-                self.repo = self.repo.git_clone_shallow(&temp_dir.as_path()).unwrap()
-            }
-            false => {
-                debug!("Deep clone");
-                self.repo = self.repo.git_clone(&temp_dir.as_path())?
-            }
-        };
-
-        let mut branch_heads_state = self
-            .repo
-            .get_remote_branch_head_refs(self.branch_filter.clone())?;
+        if pre_run {
+            closure(branch_heads_state.clone());
+        }
 
         loop {
             sleep(self.poll_freq);
 
-            let snapshot = self
-                .repo
-                .get_remote_branch_head_refs(self.branch_filter.clone())?;
+            let snapshot = &self.state.clone().unwrap().branch_heads;
 
             for (branch, commit) in snapshot.clone() {
-                match branch_heads_state.get(&branch) {
+                match branch_heads_state.branch_heads.get(&branch) {
                     Some(c) => {
                         if &commit == c {
                             info!("No new commits in branch {} found", branch);
                         } else {
                             info!("New commit in branch {} found", branch);
-                            closure();
+                            closure(
+                                self.state
+                                    .clone()
+                                    .expect("No state found in GitRepoWatcherHandler"),
+                            );
                         }
                     }
                     None => {
                         info!("New branch '{}' found", branch);
-                        closure();
+                        closure(
+                            self.state
+                                .clone()
+                                .expect("No state found in GitRepoWatcherHandler"),
+                        );
                     }
                 }
             }
 
-            branch_heads_state = snapshot;
+            branch_heads_state = self.update_state().await?;
+        }
+    }
+
+    pub fn watch_new_commits_sync<F>(&mut self, pre_run: bool, closure: F) -> Result<()>
+    where
+        F: Fn(GitRepoState),
+    {
+        let mut branch_heads_state = self.update_state_sync()?;
+
+        if pre_run {
+            closure(
+                self.state
+                    .clone()
+                    .expect("No state found in GitRepoWatcherHandler"),
+            );
+        }
+
+        loop {
+            sleep(self.poll_freq);
+
+            let snapshot = &self.state.clone().unwrap().branch_heads;
+
+            for (branch, commit) in snapshot.clone() {
+                match branch_heads_state.branch_heads.get(&branch) {
+                    Some(c) => {
+                        if &commit == c {
+                            info!("No new commits in branch {} found", branch);
+                        } else {
+                            info!("New commit in branch {} found", branch);
+                            closure(
+                                self.state
+                                    .clone()
+                                    .expect("No state found in GitRepoWatcherHandler"),
+                            );
+                        }
+                    }
+                    None => {
+                        info!("New branch '{}' found", branch);
+                        closure(
+                            self.state
+                                .clone()
+                                .expect("No state found in GitRepoWatcherHandler"),
+                        );
+                    }
+                }
+            }
+
+            branch_heads_state = self.update_state_sync()?;
         }
     }
 }


### PR DESCRIPTION
- User can read the current GitRepoState
- Ability to start state on a specific commit using `with_commit`
- Modified paths between commits are identified
Progress on #9